### PR TITLE
react!: move AssertLogger utility class to org.usefultoys.slf4jtestmock

### DIFF
--- a/src/main/java/org/slf4j/impl/MockLogger.java
+++ b/src/main/java/org/slf4j/impl/MockLogger.java
@@ -21,6 +21,7 @@ import lombok.Setter;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
 import org.slf4j.impl.MockLoggerEvent.Level;
+import org.usefultoys.slf4jtestmock.AssertLogger;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;

--- a/src/main/java/org/usefultoys/slf4jtestmock/AssertLogger.java
+++ b/src/main/java/org/usefultoys/slf4jtestmock/AssertLogger.java
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.slf4j.impl;
+package org.usefultoys.slf4jtestmock;
 
 import lombok.experimental.UtilityClass;
 import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
+import org.slf4j.impl.MockLogger;
+import org.slf4j.impl.MockLoggerEvent;
 import org.slf4j.impl.MockLoggerEvent.Level;
 
 import java.util.List;

--- a/src/test/java/org/slf4j/impl/AssertLoggerIntegrationTest.java
+++ b/src/test/java/org/slf4j/impl/AssertLoggerIntegrationTest.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
 import org.slf4j.impl.MockLoggerEvent.Level;
+import org.usefultoys.slf4jtestmock.AssertLogger;
 
 /**
  * Integration tests demonstrating the use of {@link AssertLogger} with the SLF4J Logger interface.

--- a/src/test/java/org/slf4j/impl/AssertLoggerTest.java
+++ b/src/test/java/org/slf4j/impl/AssertLoggerTest.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
 import org.slf4j.impl.MockLoggerEvent.Level;
+import org.usefultoys.slf4jtestmock.AssertLogger;
 
 import java.io.IOException;
 


### PR DESCRIPTION
This pull request primarily refactors the package structure for the `AssertLogger` class to improve code organization and clarity. The main change is moving `AssertLogger` from the `org.slf4j.impl` package to a new package, `org.usefultoys.slf4jtestmock`, and updating all relevant imports across the codebase.

**Package refactoring:**

* Renamed and moved `AssertLogger.java` from `org/slf4j/impl` to `org/usefultoys/slf4jtestmock`, updating its package declaration accordingly.

**Import updates:**

* Updated imports in `MockLogger.java`, `AssertLoggerIntegrationTest.java`, and `AssertLoggerTest.java` to reference the new location of `AssertLogger`. [[1]](diffhunk://#diff-f91ea47cb101e3d665bf0246e3ae02f3c8960f64291a26584875b36a18a3940dR24) [[2]](diffhunk://#diff-8f99f5393615af8615b9cf76be5c287df3543abc58c2a1b089669e5ce95a2206R25) [[3]](diffhunk://#diff-48857128185b61f0de84af9a63501017623051060e3b5fc7f2e5a79d82a8eb7eR25)