### PR TITLE
Sync AI instructions

### DIFF
--- a/AI-INSTRUCTIONS.md
+++ b/AI-INSTRUCTIONS.md
@@ -35,9 +35,9 @@ The project is built with Maven and uses the Maven wrapper for all builds.
 
 **Task-Specific Profiles**:
 - **release**: Generates Javadoc JAR, sources JAR, signs artifacts, and deploys to Maven Central
-  - Activate: `mvnw.cmd -P release deploy`
+  - Activate: `mvnw -P release deploy`
 - **validate-javadoc**: Validates Javadoc formatting and documentation completeness
-  - Activate: `mvnw.cmd -P validate-javadoc test`
+  - Activate: `mvnw -P validate-javadoc test`
 
 ## Code Standards
 
@@ -91,6 +91,57 @@ The project is built with Maven and uses the Maven wrapper for all builds.
 - Cover all meaningful combinations of parameters, even if redundant for coverage purposes
 - Prefer real-world scenarios when possible
 - Lombok-generated functionality (e.g., builders, @NonNull validation) does not require explicit testing
+
+### Test Class Javadoc Requirements
+**All test classes must include a Javadoc that documents what the tests are covering.**
+
+The test class Javadoc must include:
+1. **Brief description**: What class/feature is being tested (use `{@link ClassName}` for the class under test)
+2. **Coverage section**: Detailed list of what the tests validate and cover
+
+**Format:**
+```java
+/**
+ * Unit tests for {@link ClassUnderTest}.
+ * <p>
+ * Tests validate that ClassUnderTest correctly [main functionality description].
+ * <p>
+ * <b>Coverage:</b>
+ * <ul>
+ *   <li><b>Feature 1:</b> Description of what is validated</li>
+ *   <li><b>Feature 2:</b> Description of what is validated</li>
+ *   <li><b>Edge Case 1:</b> Description of what is validated</li>
+ * </ul>
+ */
+class MyClassTest {
+    // ... test methods
+}
+```
+
+**Example:**
+```java
+/**
+ * Unit tests for {@link Session}.
+ * <p>
+ * Tests validate that Session correctly generates and manages UUIDs,
+ * with proper immutability and formatting validation.
+ * <p>
+ * <b>Coverage:</b>
+ * <ul>
+ *   <li><b>UUID Generation:</b> Verifies that Session generates a non-null UUID on first access</li>
+ *   <li><b>UUID Immutability:</b> Ensures that the UUID remains constant across multiple accesses</li>
+ *   <li><b>UUID Format:</b> Validates that generated UUIDs are 32-character hexadecimal strings</li>
+ *   <li><b>Short UUID with Default Size:</b> Tests shortSessionUuid() method with default SessionConfig.uuidSize</li>
+ *   <li><b>Short UUID with Custom Size:</b> Tests shortSessionUuid() method with custom SessionConfig.uuidSize configuration</li>
+ * </ul>
+ */
+```
+
+This makes it clear to future readers:
+- What component is being tested
+- What specific aspects/features are covered by the test suite
+- What edge cases are handled
+- How to add new tests to extend coverage
 
 ## Documentation Standards
 


### PR DESCRIPTION
## Summary
- Syncs AI assistant instructions with current project conventions.

## Changes
- Updates profile activation examples to use mvnw instead of mvnw.cmd.
- Adds guidance requiring Javadoc on all test classes, including a coverage checklist format.

## Notes
- Documentation-only change; no runtime/library behavior changes.